### PR TITLE
docs: add v0.17.6 and v0.17.7 release notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This is the documentation website for Basic Memory (`docs.basicmemory.com`), bui
 
 **Repository**: https://github.com/basicmachines-co/basic-memory
 **Website**: https://basicmemory.com
-**Current Version**: v0.17.5 (released January 11, 2026)
+**Current Version**: v0.17.7 (released January 19, 2026)
 
 **Key Features**:
 - 17 MCP tools for AI integration (write_note, read_note, edit_note, search_notes, build_context, etc.)

--- a/src/pages/latest-releases.mdx
+++ b/src/pages/latest-releases.mdx
@@ -10,6 +10,57 @@ import { Card, CardGroup, Info, Warning, Note, Tip, Accordion, AccordionItem, St
 
 View the latest changes to Basic Memory on [GitHub](https://github.com/basicmachines-co/basic-memory/releases)
 
+## [v0.17.7](https://github.com/basicmachines-co/basic-memory/releases/tag/v0.17.7) — 2026-01-19
+
+**Focus:** MCP Registry publication and bug fixes
+
+<Info>
+**Highlights:**
+- Basic Memory is now published to the official MCP Registry
+- Fixed entity creation to properly set external_id
+- Removed OpenPanel telemetry
+</Info>
+
+### Features
+
+- **MCP Registry Publication** ([#515](https://github.com/basicmachines-co/basic-memory/pull/515))
+  - Basic Memory is now listed on the official MCP Registry at [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io)
+  - Added `server.json` for registry metadata
+  - Automated version sync during releases
+
+### Bug Fixes
+
+- **Fix external_id not set on entity creation** ([#513](https://github.com/basicmachines-co/basic-memory/pull/513))
+  - Ensures stable UUID identifiers are properly assigned when creating new entities
+
+### Internal
+
+- **Remove OpenPanel telemetry** ([#514](https://github.com/basicmachines-co/basic-memory/pull/514))
+  - Telemetry collection has been removed from the codebase
+
+**Full Changelog**: https://github.com/basicmachines-co/basic-memory/compare/v0.17.6...v0.17.7
+
+---
+
+## [v0.17.6](https://github.com/basicmachines-co/basic-memory/releases/tag/v0.17.6) — 2026-01-17
+
+**Focus:** Docker container fix and internal cleanup
+
+### Bug Fixes
+
+- **Fix Docker container Python symlink broken at runtime** ([#510](https://github.com/basicmachines-co/basic-memory/pull/510))
+  - Resolves issue where Python symlink was broken in Docker containers
+  - Ensures reliable container startup
+
+### Internal
+
+- Remove logfire config and specs docs
+- Reduce lifespan and sync logging to debug level for cleaner output
+
+**Full Changelog**: https://github.com/basicmachines-co/basic-memory/compare/v0.17.5...v0.17.6
+
+---
+
 ## [v0.17.5](https://github.com/basicmachines-co/basic-memory/releases/tag/v0.17.5) — 2026-01-11
 
 **Focus:** Python 3.14 compatibility and CLI stability


### PR DESCRIPTION
## Summary
- Add release notes for v0.17.6 and v0.17.7
- Update CLAUDE.md current version to v0.17.7

## Changes
- v0.17.7: MCP Registry publication, external_id fix, telemetry removal
- v0.17.6: Docker container Python symlink fix, internal cleanup

🤖 Generated with [Claude Code](https://claude.ai/claude-code)