### PR TITLE
docs: add v0.18.0 release notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This is the documentation website for Basic Memory (`docs.basicmemory.com`), bui
 
 **Repository**: https://github.com/basicmachines-co/basic-memory
 **Website**: https://basicmemory.com
-**Current Version**: v0.17.7 (released January 19, 2026)
+**Current Version**: v0.18.0 (released January 28, 2026)
 
 **Key Features**:
 - 17 MCP tools for AI integration (write_note, read_note, edit_note, search_notes, build_context, etc.)
@@ -23,13 +23,11 @@ This is the documentation website for Basic Memory (`docs.basicmemory.com`), bui
 - Real-time file synchronization
 - SQLite and PostgreSQL database backends
 
-**v0.17.x Major Features**:
-- API v2 migration complete - all MCP tools use optimized v2 endpoints
-- Auto-format files on save with built-in Python formatter
-- Anonymous usage telemetry (Homebrew-style opt-out)
-- CLI stability improvements - commands no longer hang on exit
-- Cloud mode discovery for recent_activity across projects
-- PostgreSQL/Neon database support as alternative to SQLite
+**v0.18.0 Major Features**:
+- Context-aware wiki link resolution with source_path support
+- Directory support for move_note and delete_note tools
+- Local MCP cloud mode routing for simultaneous local/cloud usage
+- Cloud snapshot CLI commands for backup management
 
 ### Basic Memory Cloud
 

--- a/src/pages/latest-releases.mdx
+++ b/src/pages/latest-releases.mdx
@@ -10,6 +10,73 @@ import { Card, CardGroup, Info, Warning, Note, Tip, Accordion, AccordionItem, St
 
 View the latest changes to Basic Memory on [GitHub](https://github.com/basicmachines-co/basic-memory/releases)
 
+## [v0.18.0](https://github.com/basicmachines-co/basic-memory/releases/tag/v0.18.0) — 2026-01-28
+
+**Focus:** Context-aware wiki link resolution, directory operations, and cloud routing improvements
+
+<Info>
+**Highlights:**
+- Context-aware wiki link resolution with `source_path` support
+- Directory support for move and delete operations
+- Local MCP cloud mode routing for simultaneous local/cloud usage
+- MCP prompt rendering fixes
+</Info>
+
+### Features
+
+- **Context-aware wiki link resolution** ([#527](https://github.com/basicmachines-co/basic-memory/pull/527))
+  - Add `source_path` parameter to `resolve_link()` for context-aware resolution
+  - Relative path resolution: `[[nested/note]]` from `folder/file.md` → `folder/nested/note.md`
+  - Proximity-based resolution for duplicate titles (prefers notes in same folder)
+  - Strict mode to disable fuzzy search fallback for wiki links
+
+- **Directory support for move and delete** ([#518](https://github.com/basicmachines-co/basic-memory/pull/518))
+  - Add `is_directory` parameter to `move_note` and `delete_note` MCP tools
+  - New `POST /move-directory` and `POST /delete-directory` API endpoints
+  - Rename `folder` → `directory` parameter across codebase for consistency
+
+- **Local MCP cloud mode routing** ([#522](https://github.com/basicmachines-co/basic-memory/pull/522))
+  - Add `--local` and `--cloud` CLI routing flags
+  - Local MCP server (`basic-memory mcp`) automatically uses local routing
+  - Enables simultaneous use of local Claude Desktop and cloud-based clients
+  - Environment variable `BASIC_MEMORY_FORCE_LOCAL=true` for global override
+
+### Bug Fixes
+
+- **Fix MCP prompt rendering errors** ([#524](https://github.com/basicmachines-co/basic-memory/pull/524))
+  - Fix "Error rendering prompt recent_activity" error
+  - Change `TimeFrame` to `str` in prompt type annotations for FastMCP compatibility
+
+**Full Changelog**: https://github.com/basicmachines-co/basic-memory/compare/v0.17.9...v0.18.0
+
+---
+
+## [v0.17.8-v0.17.9](https://github.com/basicmachines-co/basic-memory/releases/tag/v0.17.9) — 2026-01-24
+
+**Focus:** Cloud mode bug fixes and snapshot CLI commands
+
+### Features
+
+- **Cloud snapshot CLI commands** ([#476](https://github.com/basicmachines-co/basic-memory/pull/476))
+  - New `basic-memory cloud snapshot` commands: `create`, `list`, `delete`, `show`, `browse`
+  - Manage cloud backups directly from the command line
+
+### Bug Fixes
+
+- **Fix `get_default_project()` returning multiple results** ([#521](https://github.com/basicmachines-co/basic-memory/pull/521))
+  - Query incorrectly matched any project with non-NULL `is_default` (both True and False)
+  - Now correctly checks for `is_default=True` only
+
+- **Fix `remove_project()` checking stale config in cloud mode** ([#523](https://github.com/basicmachines-co/basic-memory/pull/523))
+  - In cloud mode, only check database `is_default` field (source of truth)
+  - Config file can become stale when users set default project via v2 API
+
+- **Read default project from database in cloud mode** ([#520](https://github.com/basicmachines-co/basic-memory/pull/520))
+
+**Full Changelog**: https://github.com/basicmachines-co/basic-memory/compare/v0.17.7...v0.17.9
+
+---
+
 ## [v0.17.7](https://github.com/basicmachines-co/basic-memory/releases/tag/v0.17.7) — 2026-01-19
 
 **Focus:** MCP Registry publication and bug fixes

--- a/src/pages/whats-new.mdx
+++ b/src/pages/whats-new.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '@/layouts/DocsLayout.astro'
-title: "What's New - Basic Memory Cloud is live!"
-description: 'Bring your knowledge to the cloud. All your existing notes, connections, and context - accessible from anywhere.'
+title: "What's New in Basic Memory"
+description: 'Latest features and improvements in Basic Memory - context-aware wiki links, directory operations, and cloud sync.'
 ---
 
 import { Card, CardGroup, Info, Warning, Note, Tip, Accordion, AccordionItem, Steps, Step } from '@/components'
@@ -13,6 +13,62 @@ import { Card, CardGroup, Info, Warning, Note, Tip, Accordion, AccordionItem, St
 </Tip>
 
 Work with your knowledge base across multiple devices using cloud sync and storage.
+
+## v0.18.0
+
+Basic Memory v0.18.0 introduces context-aware wiki link resolution, directory operations, and improved cloud routing.
+
+<Info>
+**Key improvements:**
+- Context-aware wiki link resolution with `source_path` support
+- Directory support for `move_note` and `delete_note` tools
+- Local MCP cloud mode routing for simultaneous local/cloud usage
+- MCP prompt rendering fixes
+</Info>
+
+### Context-Aware Wiki Link Resolution
+
+Wiki links now resolve intelligently based on where they appear in your knowledge base.
+
+**Relative path resolution:**
+When you write `[[nested/note]]` in a file at `folder/file.md`, Basic Memory first looks for `folder/nested/note.md` before searching globally.
+
+**Proximity-based resolution:**
+If you have notes with the same title in different folders, links resolve to the note closest to your current location. A link to `[[Meeting Notes]]` from `projects/alpha/tasks.md` prefers `projects/alpha/Meeting Notes.md` over `projects/beta/Meeting Notes.md`.
+
+**Strict mode:**
+The resolve endpoint now supports strict mode to disable fuzzy search fallback, ensuring exact matches only.
+
+### Directory Operations
+
+Move and delete entire folders of notes with database consistency:
+
+```python
+# Move all notes in a directory
+move_note("old-folder", "new-folder", is_directory=True)
+
+# Delete all notes in a directory
+delete_note("archive/old-project", is_directory=True)
+```
+
+### Local/Cloud Routing
+
+Use local Claude Desktop and cloud-based clients simultaneously:
+
+```bash
+# Force local routing (when cloud mode is enabled)
+basic-memory status --local
+basic-memory project list --local
+
+# Force cloud routing
+basic-memory status --cloud
+```
+
+The local MCP server (`basic-memory mcp`) automatically uses local routing, so you can run both without conflicts.
+
+See the [complete v0.18.0 changelog](/latest-releases) for full details.
+
+---
 
 ## v0.17.0
 


### PR DESCRIPTION
## Summary
- Add v0.18.0 release notes with context-aware wiki link resolution, directory operations, and cloud routing improvements
- Add v0.17.8-v0.17.9 release notes (cloud snapshot CLI, bug fixes)
- Update whats-new page with v0.18.0 feature highlights
- Update CLAUDE.md current version to v0.18.0

## Test plan
- [ ] Verify pages render correctly with `npm run dev`
- [ ] Check links work properly

🤖 Generated with [Claude Code](https://claude.ai/code)