### PR TITLE
Add sitemap.xml and robots.txt for SEO

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,6 @@
 export default defineNuxtConfig({
   extends: ['docus'],
+  modules: ['@nuxtjs/sitemap'],
   compatibilityDate: '2025-07-15',
   app: {
     head: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "basic-memory-docs",
       "dependencies": {
+        "@nuxtjs/sitemap": "^7.6.0",
         "beautiful-mermaid": "^0.1.3",
         "better-sqlite3": "^12.5.0",
         "docus": "latest",
@@ -2569,8 +2570,9 @@
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3918,6 +3920,55 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nuxtjs/sitemap": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/sitemap/-/sitemap-7.6.0.tgz",
+      "integrity": "sha512-JuWwAFn9MDHWFO5C7lpV6DS86ZIrJItGfzCK1kN9WvgvDmTgal3xbfGCADmAaCWOVl2+dcPGHH6BCypQvUX0aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/devtools-kit": "^3.1.1",
+        "@nuxt/kit": "^4.3.0",
+        "chalk": "^5.6.2",
+        "defu": "^6.1.4",
+        "fast-xml-parser": "^5.3.3",
+        "nuxt-site-config": "^3.2.18",
+        "ofetch": "^1.5.1",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "radix3": "^1.1.2",
+        "semver": "^7.7.3",
+        "sirv": "^3.0.2",
+        "std-env": "^3.10.0",
+        "ufo": "^1.6.3",
+        "ultrahtml": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "zod": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxtjs/sitemap/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@oxc-minify/binding-android-arm-eabi": {
@@ -10801,6 +10852,37 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -19145,6 +19227,18 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/structured-clone-es": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "node .output/server/index.mjs"
   },
   "dependencies": {
+    "@nuxtjs/sitemap": "^7.6.0",
     "beautiful-mermaid": "^0.1.3",
     "better-sqlite3": "^12.5.0",
     "docus": "latest",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.basicmemory.com/sitemap.xml


### PR DESCRIPTION
docs.basicmemory.com is our highest-traffic property (74 clicks/week on /integrations/codex) but has no sitemap — Google discovers pages purely through links.

**Changes:**
- Add `@nuxtjs/sitemap` module — auto-generates sitemap from all Nuxt routes
- Add `robots.txt` with sitemap reference
- `site.url` was already configured in nuxt.config.ts

After deploy, the sitemap will be auto-submitted via robots.txt. Can also manually submit in Search Console (service account already connected).

Closes #11