### PR TITLE
ci: disable Claude Code Review workflow (broken auth)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,25 @@
 name: Claude Code Review
 
+# DISABLED 2026-05-18: the org disabled Claude subscription access for Claude
+# Code, and this workflow has no ANTHROPIC_API_KEY fallback, so it fails in
+# ~19s on every PR before reviewing anything. It is a review bot, not a
+# build/correctness gate. Trigger is set to workflow_dispatch only so the
+# config is preserved and easy to restore.
+#
+# To re-enable: fix auth (re-enable Claude subscription access for Claude
+# Code in org settings, OR add an ANTHROPIC_API_KEY repo secret and wire it
+# into the action's `with:` block), then restore the pull_request trigger
+# that is commented out below.
 on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
+  # pull_request:
+  #   types: [opened, synchronize]
+  #   # Optional: Only run on specific file changes
+  #   # paths:
+  #   #   - "src/**/*.ts"
+  #   #   - "src/**/*.tsx"
+  #   #   - "src/**/*.js"
+  #   #   - "src/**/*.jsx"
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Problem
`claude-code-review.yml` fails on **every** PR in ~19s with:

```
Your organization has disabled Claude subscription access for Claude Code
· Use an Anthropic API key instead, or ask your admin to enable access
```

`ANTHROPIC_API_KEY` is unset, so there's no fallback. It dies before reading the diff — no review is produced. This is **pre-existing and repo-wide**, not introduced by any recent PR: it also failed on the unrelated `codex/fix-schema-picoschema-examples` branch back on 2026-05-06. It went unnoticed because the workflow is PR-only (runs on `main` are `skipped`).

It is a non-blocking review bot — there is no build or lint gate on this repo — so the failure is cosmetic but red-Xes every PR and obscures real signal.

## Change
Switch the trigger to `workflow_dispatch` only. The `pull_request` trigger is preserved commented-out, with a header comment explaining why it's disabled and exactly how to restore it.

## To re-enable (separate, admin-level)
Either:
- Re-enable Claude subscription access for Claude Code in org settings, **or**
- Add an `ANTHROPIC_API_KEY` repo secret and wire it into the action's `with:` block

…then uncomment the `pull_request` trigger.

## Note
This unblocks PR #18 (Hermes docs) and any other open/future PRs. Self-evidently can't be reviewed by the very bot it disables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)