### PR TITLE
Update built-in memory facts for ChatGPT and Claude (June 2026)

### DIFF
--- a/content/1.start-here/1.what-is-basic-memory.md
+++ b/content/1.start-here/1.what-is-basic-memory.md
@@ -254,7 +254,7 @@ AI: [Makes a note in its own memory to keep notes annotated with semantic inform
 
 ## Seeing into the black box
 
-AI memory is typically opaque - you don't know what context the AI has or what it "remembers." Basic Memory makes this transparent.
+Built-in AI memory shows you a short digest at best - not the full context the AI draws on or how it got there. Basic Memory makes all of it transparent.
 
 - **See what your AI sees** - Every piece of context is a file you can read
 - **Edit what your AI knows** - Modify, delete, or reorganize knowledge anytime

--- a/content/1.start-here/5.why-basic-memory.md
+++ b/content/1.start-here/5.why-basic-memory.md
@@ -3,7 +3,7 @@ title: Why Basic Memory
 description: Your AI already has memory features. Here's why you still want a knowledge base you own — and how Basic Memory is different from the alternatives.
 ---
 
-Every AI tool is adding memory. Claude has CLAUDE.md and auto memory. ChatGPT remembers facts about you. Obsidian users have been doing this with markdown for years. And a new wave of startups is building memory-as-a-service on top of databases.
+Every AI tool is adding memory. Claude builds a memory summary from your chats, and Claude Code has CLAUDE.md and auto memory. ChatGPT remembers facts about you. Obsidian users have been doing this with markdown for years. And a new wave of startups is building memory-as-a-service on top of databases.
 
 So why Basic Memory?
 
@@ -15,14 +15,14 @@ Because none of these solve the whole problem. They each handle a piece of it, b
 
 ### 1. Built-in AI memory
 
-Claude, ChatGPT, Cursor, and others now ship with some form of memory. Claude Code has CLAUDE.md files and auto memory. ChatGPT has saved memories and reference chat history. These are useful for quick preferences — "I use TypeScript," "I'm vegetarian," "use 2-space indentation."
+Claude, ChatGPT, Cursor, and others now ship with some form of memory. Claude builds an editable memory summary from your chat history, with a separate memory for each Project. Claude Code has CLAUDE.md files and auto memory. ChatGPT has saved memories and reference chat history. These are useful for quick preferences and recurring context — "I use TypeScript," "I'm vegetarian," "use 2-space indentation."
 
 **Where it falls short:**
 
-- **Short-form only.** ChatGPT memories are single sentences. Claude Code's auto memory index caps at 200 lines. You can't store a detailed architecture decision, a meeting summary, or a research synthesis.
-- **Siloed.** Claude's memory only works in Claude. ChatGPT's only works in ChatGPT. If you use more than one AI tool, your knowledge is fragmented. A decision captured in Claude Code isn't available when you switch to Cursor or ChatGPT.
-- **Not searchable.** There's no semantic search, no knowledge graph, no way to ask "find everything related to our authentication approach" and get structured results.
-- **Not yours to keep.** If the platform changes its terms, shuts down, or you switch tools, your memories don't come with you.
+- **Capacity-limited.** ChatGPT's saved memories top out around 1,200–1,400 words total — once full, nothing new is saved until you delete entries. Claude keeps one rolling summary per account (plus one per Project). Claude Code's auto memory index caps at 200 lines. None of them can hold a detailed architecture decision, a meeting summary, or a research synthesis.
+- **Siloed.** Claude's memory only works in Claude. ChatGPT's only works in ChatGPT. Each one also learns only from its own conversations — it can't ingest your docs, repos, or existing notes. If you use more than one AI tool, your knowledge is fragmented. A decision captured in Claude Code isn't available when you switch to Cursor or ChatGPT.
+- **Search stops at chat history.** Claude can search past conversations and ChatGPT can reference chat history, but there's no semantic search over structured knowledge, no knowledge graph, no way to ask "find everything related to our authentication approach" and get structured results.
+- **Not yours to keep.** Your memories live in your account on that platform — they're not portable files. If the platform changes its terms, shuts down, or you switch tools, your memories don't come with you.
 
 Basic Memory works alongside built-in memory — it doesn't replace it. Use built-in memory for preferences. Use Basic Memory for everything deeper. See [Basic Memory vs Built-in AI Memory](/concepts/vs-built-in-memory) for the detailed comparison.
 

--- a/content/6.concepts/0.vs-built-in-memory.md
+++ b/content/6.concepts/0.vs-built-in-memory.md
@@ -11,12 +11,17 @@ For a broader comparison of Basic Memory with all the alternatives — including
 
 ## What each tool offers
 
+**Claude** (web, desktop, and mobile) has a memory system available to all users:
+- **Memory summary** — Claude automatically synthesizes a summary of you from your chat history, refreshed roughly every 24 hours. You can view and edit it (Settings → Capabilities → "View and edit memory"), or update it just by asking Claude in chat.
+- **Project memory** — Each Claude Project gets its own isolated memory space and summary.
+- **Chat search** — Claude can also search your raw conversation history. Controls include pausing memory, resetting it, and incognito chats.
+
 **Claude Code** has two built-in systems:
 - **CLAUDE.md files** — Instructions you write for how Claude should work in a project. Coding standards, build commands, architectural conventions.
 - **Auto memory** — Notes Claude writes itself when it notices patterns or preferences. Stored in `~/.claude/projects/` as markdown files. The first 200 lines of `MEMORY.md` load into every session.
 
 **ChatGPT** has two memory systems:
-- **Saved memories** — Facts you tell it to remember ("I'm vegetarian," "I live in San Francisco"). These persist until you delete them. ChatGPT may also save details on its own if they seem useful.
+- **Saved memories** — Facts you tell it to remember ("I'm vegetarian," "I live in San Francisco"). These persist until you delete them, and total capacity is limited to roughly 1,200–1,400 words — once full, nothing new is saved until you delete entries. ChatGPT may also save details on its own if they seem useful. The Manage Memories panel lets you view and delete entries; to change one, ask ChatGPT in chat.
 - **Reference chat history** — ChatGPT can look back at past conversations to pick up preferences and context. Unlike saved memories, these details change over time as ChatGPT decides what's most relevant.
 
 **Cursor** has a "Memories" feature for storing brief preference strings and rules.
@@ -33,13 +38,16 @@ The best setup uses both. Here's how they complement each other:
 |---|---|---|
 | **Best for** | Quick preferences, tool-specific rules | Structured knowledge, decisions, research |
 | **Scope** | One AI tool | Every AI tool you use |
-| **Format** | Short text / instructions | Full markdown notes with semantic structure |
-| **Search** | None | Semantic, text, metadata, and tag search |
+| **Source** | That tool's own chats | Anything — chats, docs, your own writing |
+| **Format** | Short summaries / instructions | Full markdown notes with semantic structure |
+| **Search** | That tool's chat history | Semantic, text, metadata, and tag search |
 | **Connections** | None | Knowledge graph with typed relations |
-| **Portability** | Locked to one tool | Plain files, works everywhere |
+| **Portability** | Bound to your account | Plain files, works everywhere |
 | **Setup** | Automatic | One-time MCP connection |
 
 ### In practice
+
+**Claude:** Let Claude's memory summary and project memory handle who you are and what you're working on — it builds that automatically, and you can edit it in Settings. Use Basic Memory for knowledge at a different scale: full notes, decision records, and research that one rolling summary can't hold, and that you can open in any other tool.
 
 **Claude Code:** Use CLAUDE.md for project instructions ("use 2-space indentation," "run tests before committing"). Use auto memory for small learnings Claude picks up. Use Basic Memory for everything deeper — architecture decisions, API design notes, research, meeting summaries, project context that you want searchable and linked.
 


### PR DESCRIPTION
Fact-check pass on our claims about built-in AI memory features. Claude's memory shipped to all users (~March 2026) and ChatGPT's memory behavior is better documented now, so several claims were stale. Changes keep each page's structure and the "use both together" positioning — corrections only.

## Claims changed

### `content/6.concepts/0.vs-built-in-memory.md`
- **Before:** Page described only Claude Code's memory (CLAUDE.md + auto memory); the Claude apps had no entry. **After:** Added a Claude (web/desktop/mobile) section covering the auto-synthesized memory summary (refreshed ~24h, viewable/editable via Settings → Capabilities or by asking in chat), per-Project memory, chat search, and pause/reset/incognito controls.
- **Before (ChatGPT saved memories):** "These persist until you delete them." **After:** Added the ~1,200–1,400-word total capacity (no new memories saved when full) and that the Manage Memories panel is view/delete — updates happen by asking ChatGPT in chat.
- **Before (comparison table):** Search: "None"; Portability: "Locked to one tool"; Format: "Short text / instructions." **After:** Search: "That tool's chat history" (Claude chat search and ChatGPT reference-chat-history exist); Portability: "Bound to your account"; Format: "Short summaries / instructions." Added a **Source** row (that tool's own chats vs. any content).
- Added a Claude paragraph to "In practice" mirroring the Claude Code/ChatGPT/Cursor guidance.

### `content/1.start-here/5.why-basic-memory.md`
- **Before:** "Claude has CLAUDE.md and auto memory." **After:** "Claude builds a memory summary from your chats, and Claude Code has CLAUDE.md and auto memory."
- **Before:** "**Short-form only.** ChatGPT memories are single sentences." **After:** "**Capacity-limited.**" with the ~1,200–1,400-word ChatGPT cap and Claude's one rolling summary per account (plus one per Project).
- **Before:** "**Not searchable.** There's no semantic search…" **After:** "**Search stops at chat history.**" — acknowledges Claude chat search and ChatGPT history reference, keeps the no-knowledge-graph/structured-results point.
- **Siloed** and **Not yours to keep** bullets kept (still accurate), with a note that each system learns only from its own vendor's chats and that memories aren't portable files.

### `content/1.start-here/1.what-is-basic-memory.md`
- **Before:** "AI memory is typically opaque - you don't know what context the AI has or what it 'remembers.'" **After:** "Built-in AI memory shows you a short digest at best - not the full context the AI draws on or how it got there." (Claude's summary is now viewable/editable and ChatGPT lists saved memories, so "opaque" was too strong.)

## Not changed
- `content/7.integrations/2.claude-code.md` — its claims are about Claude Code's CLAUDE.md/auto memory, which are still accurate.
- The deliberately avoided overclaims: we do not say "you can't edit ChatGPT memories" (chat-mediated updates work) or "you can't see Claude's memory" (you can, now).

## Sources
- Anthropic help center article 11817273 (Claude memory: summary, per-Project memory, view/edit, pause/reset, incognito); VentureBeat and 2026 coverage of the all-users rollout
- OpenAI Memory FAQ (saved memories vs. reference chat history, capacity behavior, manage panel is view/delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)