### PR TITLE
Fix stale search-notes CLI flags in docs examples

### DIFF
--- a/content/5.local/2.cli-basics.md
+++ b/content/5.local/2.cli-basics.md
@@ -25,14 +25,14 @@ bm project default "research"
 ## Search notes
 
 ```bash
-bm tool search-notes --query "authentication"
+bm tool search-notes "authentication"
 ```
 
 Semantic modes:
 
 ```bash
-bm tool search-notes --query "authentication architecture" --search-type hybrid
-bm tool search-notes --query "login flow" --search-type vector
+bm tool search-notes "authentication architecture" --hybrid
+bm tool search-notes "login flow" --vector
 ```
 
 ## Read and write notes

--- a/content/6.concepts/7.semantic-search.md
+++ b/content/6.concepts/7.semantic-search.md
@@ -37,11 +37,11 @@ You: "Search my notes for project AND planning"
 AI: [Finds notes containing both words]
 ```
 ```bash [CLI]
-bm tool search-notes --query "project AND planning" --search-type text
+bm tool search-notes "project AND planning"
 ```
 ::
 
-Best when you know the exact terms — names, identifiers, tags.
+Best when you know the exact terms — names, identifiers, tags. The CLI doesn't have a text-only flag — keyword matching (including `AND`/`OR` operators) runs as part of the default hybrid search, and searches are text-only when semantic search is disabled.
 
 ### Vector
 
@@ -53,7 +53,7 @@ You: "Find notes about ways to make the frontend faster"
 AI: [Finds notes about React performance, bundle size, lazy loading]
 ```
 ```bash [CLI]
-bm tool search-notes --query "ways to make the frontend faster" --search-type vector
+bm tool search-notes "ways to make the frontend faster" --vector
 ```
 ::
 
@@ -69,7 +69,7 @@ You: "Search for authentication security"
 AI: [Finds notes matching the words AND notes about related concepts]
 ```
 ```bash [CLI]
-bm tool search-notes --query "authentication security"
+bm tool search-notes "authentication security"
 ```
 ::
 
@@ -83,7 +83,7 @@ Basic Memory describes each search mode to your AI, so it already knows when to 
 - "Search for the exact phrase project AND planning" — the AI switches to text search
 - "What have I written about handling failures gracefully?" — the AI uses vector search
 
-If you're using the CLI directly, hybrid is the default and covers most cases. Use `--search-type text` when you need exact keyword matches, or `--search-type vector` when you're exploring by concept.
+If you're using the CLI directly, pass the query as an argument — hybrid is the default and covers most cases. Use `--vector` when you're exploring by concept, or `--hybrid` to combine both explicitly.
 
 ---
 
@@ -99,7 +99,7 @@ You: "Search for notes tagged security"
 You: "Search for tag:coffee AND tag:brewing"
 ```
 ```bash [CLI]
-bm tool search-notes --query "tag:security"
+bm tool search-notes "tag:security"
 ```
 ::
 

--- a/content/7.integrations/7.vscode.md
+++ b/content/7.integrations/7.vscode.md
@@ -107,8 +107,8 @@ Open VS Code's integrated terminal for quick operations:
 
 ```bash
 # Search your knowledge base (including semantic search)
-bm tool search-notes --query "authentication flow"
-bm tool search-notes --query "how to handle errors" --search-type hybrid
+bm tool search-notes "authentication flow"
+bm tool search-notes "how to handle errors" --hybrid
 
 # Check recent activity
 bm tool recent-activity --timeframe "2 days"
@@ -121,7 +121,7 @@ Set up aliases in your shell profile (`.bashrc`, `.zshrc`, etc.) for faster acce
 
 ```bash
 alias note="bm tool write-note"
-alias search="bm tool search-notes --query"
+alias search="bm tool search-notes"
 alias recent="bm tool recent-activity"
 ```
 
@@ -137,7 +137,7 @@ VS Code's Copilot Chat now supports MCP servers. You can add Basic Memory as an 
 Check sync status with `bm status` and verify file permissions in your project directory.
 
 **Search missing results?**
-VS Code's built-in search works for text matches. For knowledge graph queries and semantic search, use the CLI: `bm tool search-notes --query "your query"`.
+VS Code's built-in search works for text matches. For knowledge graph queries and semantic search, use the CLI: `bm tool search-notes "your query"`.
 
 **Cloud sync conflicts?**
 Run `bm cloud bisync --name my-project --dry-run` to preview before syncing. See the [Cloud Sync Guide](/cloud/cloud-sync) for conflict resolution.


### PR DESCRIPTION
## Summary

Fixes #22 — thanks @cderv for the report.

The docs showed `bm tool search-notes --query "..." --search-type text`, but the current CLI takes the query as a positional argument and uses mode flags (`--vector`, `--hybrid`) instead of `--search-type`. Updated every affected example:

- `content/6.concepts/7.semantic-search.md` — the page from the issue: all CLI examples in the search-modes and tag-filter sections
- `content/5.local/2.cli-basics.md` — search examples
- `content/7.integrations/7.vscode.md` — terminal examples, the shell alias, and the troubleshooting tip

One wording change beyond flag swaps: the CLI has no text-only mode flag (keyword matching runs as part of the default hybrid search, and search falls back to text-only when semantic search is disabled), so the Text section now says that instead of pointing at a nonexistent `--search-type text`.

The CLI reference page (`9.reference/1.cli-reference.md`) was already correct, and a sweep for other `search-notes` usage found no other stale examples.

## Verification

Each corrected command form was run against basic-memory 0.21.6 and exits cleanly:

```
bm tool search-notes "project AND planning"
bm tool search-notes "login flow" --vector
bm tool search-notes "authentication architecture" --hybrid
bm tool search-notes "tag:security"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)