### PR TITLE
Cross-link integration docs to the marketing /for pages

### DIFF
--- a/content/7.integrations/2.claude-code.md
+++ b/content/7.integrations/2.claude-code.md
@@ -5,6 +5,8 @@ description: "Give Claude Code persistent memory with Basic Memory. Decisions, a
 
 Claude Code is powerful, but every session starts from zero. Basic Memory gives it a persistent knowledge base -- so your AI remembers project decisions, code patterns, and context across every session.
 
+> New to this setup? [Basic Memory for Claude Code](https://basicmemory.com/for/claude-code) has a two-minute overview of what persistent memory changes.
+
 ## Cloud Setup
 
 ::steps

--- a/content/7.integrations/5.codex.md
+++ b/content/7.integrations/5.codex.md
@@ -5,6 +5,8 @@ description: "Give OpenAI Codex persistent memory with Basic Memory and MCP. Arc
 
 OpenAI Codex is a powerful coding agent, but it starts fresh every time. Basic Memory gives it persistent context through MCP — architecture decisions, API designs, and project knowledge carry over between sessions. Notes created in Codex are immediately available in Claude Code, Cursor, Claude Desktop, or any other MCP client.
 
+> New to this setup? [Basic Memory for Codex](https://basicmemory.com/for/codex) has a two-minute overview of what persistent memory changes.
+
 Codex comes in two forms, and both connect to Basic Memory:
 
 - **Codex app** — the agent inside ChatGPT (or the Codex desktop app)

--- a/content/7.integrations/6.cursor.md
+++ b/content/7.integrations/6.cursor.md
@@ -5,6 +5,8 @@ description: "Give Cursor persistent memory with Basic Memory. Full notes, seman
 
 Cursor's built-in memories store short preference strings. Basic Memory gives it a full knowledge base — searchable notes with semantic connections that persist across every session and grow with your project.
 
+> New to this setup? [Basic Memory for Cursor](https://basicmemory.com/for/cursor) has a two-minute overview of what persistent memory changes.
+
 ## Cloud Setup
 
 ::steps

--- a/content/7.integrations/7.vscode.md
+++ b/content/7.integrations/7.vscode.md
@@ -5,6 +5,8 @@ description: Edit your Basic Memory knowledge base directly in VS Code with full
 
 Edit your knowledge base directly in VS Code -- full syntax highlighting, markdown preview, and the Basic Memory CLI right in your terminal.
 
+> New to this setup? [Basic Memory for VS Code](https://basicmemory.com/for/vscode) has a two-minute overview of what persistent memory changes.
+
 ## Cloud Sync Workflow
 
 Basic Memory Cloud lets you edit locally in VS Code while keeping notes synced to the cloud.

--- a/content/7.integrations/8.obsidian.md
+++ b/content/7.integrations/8.obsidian.md
@@ -5,6 +5,8 @@ description: Visualize your knowledge graph and edit notes directly in Obsidian.
 
 Obsidian gives you a visual window into your Basic Memory knowledge base. Point it at your Basic Memory folder and you get graph view, backlinks, rich editing, and more — while your AI keeps working through MCP tools on the same files.
 
+> New to this setup? [Basic Memory for Obsidian](https://basicmemory.com/for/obsidian) has a two-minute overview of what persistent memory changes.
+
 ::note
 For more information about Obsidian, <a href="https://obsidian.md" target="_blank">visit the Obsidian home page</a>.
 ::


### PR DESCRIPTION
Adds one contextual link after the intro of each integration page (claude-code, codex, cursor, vscode, obsidian) pointing to the matching `basicmemory.com/for/<tool>` page.

Why now: GSC shows the docs Codex page started ranking for a new "codex memory" query cluster last week (47/26/18 impressions from zero). The marketing `/for/*` pages are the converting destination for that intent; this passes the ranking page's authority along. The marketing pages already link back to docs via their setup sections, so this completes the loop.

Format: a single `>` blockquote line per page — "New to this setup? [Basic Memory for X](…) has a two-minute overview…" — kept deliberately light to preserve docs neutrality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)