### PR TITLE
docs: add brew trust step to Homebrew install instructions

### DIFF
--- a/content/1.start-here/3.quickstart-local.md
+++ b/content/1.start-here/3.quickstart-local.md
@@ -25,8 +25,13 @@ Choose your installation method. All installs include semantic search for hybrid
 
 ```bash
 brew tap basicmachines-co/basic-memory
+brew trust basicmachines-co/basic-memory
 brew install basic-memory
 ```
+
+::note
+`brew trust` tells Homebrew you accept code from this third-party tap. Recent Homebrew versions warn about untrusted taps, and Homebrew 6 will require the trust step before installing or upgrading from them. On older Homebrew versions the command doesn't exist yet — just skip it.
+::
 
 ### All platforms (uv)
 

--- a/content/5.local/1.local-install.md
+++ b/content/5.local/1.local-install.md
@@ -14,8 +14,13 @@ uv tool install basic-memory
 
 ```bash [homebrew]
 brew tap basicmachines-co/basic-memory
+brew trust basicmachines-co/basic-memory
 brew install basic-memory
 ```
+::
+
+::note
+If you install with Homebrew: `brew trust` tells Homebrew you accept code from this third-party tap. Recent Homebrew versions warn about untrusted taps, and Homebrew 6 will require the trust step before installing or upgrading from them. On older Homebrew versions the command doesn't exist yet — just skip it.
 ::
 
 ## Start the MCP server


### PR DESCRIPTION
Homebrew now warns that the basicmachines-co/basic-memory tap is untrusted, and Homebrew 6.0 (or 5.2) will require explicit trust before installing or upgrading from third-party taps. Tap trust is user-granted by design, so the install docs need to show the step.

Adds `brew trust basicmachines-co/basic-memory` to both Homebrew install snippets (quickstart-local and local-install) with a short note — including that older Homebrew versions don't have the command yet and can skip it.

Companion change: basicmachines-co/homebrew-basic-memory#1 surfaces the same hint in the formula caveats.

(This commit was originally pushed to the release/v0.22.0 branch just after #27 merged, so it's re-rolled here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)