### PR TITLE
docs: add v0.22.1 patch notes

### DIFF
--- a/content/2.whats-new/1.v0.22.0.md
+++ b/content/2.whats-new/1.v0.22.0.md
@@ -7,6 +7,21 @@ v0.22.0 makes cloud sync safe for teams. New **`bm cloud push`** and **`bm cloud
 
 ---
 
+## v0.22.1 patch
+
+A follow-up patch to v0.22.0 focused on first-run reliability:
+
+- **Fresh installs no longer get stuck** when the projects table is empty — Basic Memory now routes you to project setup and promotes your first project to the default automatically.
+- **Sync skips projects without a valid local path** and ignores stale projects left in the database but missing from your config.
+- **MCP qualified project routes** resolve workspace display names and tenant ids correctly.
+- **`search_notes`** comma-splits `note_types`, `entity_types`, and `categories`, matching how tags already behave.
+- **`write_note`** gains a `workspace` parameter for parity with `edit_note`.
+- **Faster CLI startup** — heavy imports are deferred out of the command path.
+
+Full details in the [changelog](/whats-new/changelog).
+
+---
+
 ## Team-Safe Push and Pull
 
 `push` and `pull` model `git push` / `git pull`: additive, conflict-aware transfers that work on both Personal and Team workspaces.


### PR DESCRIPTION
Appends a short v0.22.1 patch section to the current What's New page (per the patch-release path in the version-bump checklist — no new page, badge unchanged).

Highlights: fresh-install project/default resolution fixes, sync project selection, MCP qualified-route resolution, `search_notes` list-param comma-splitting, `write_note` workspace parity, and faster CLI startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)