### PR TITLE
docs(teams): prefer "team workspace" over "organization workspace"

### DIFF
--- a/content/4.teams/1.about.md
+++ b/content/4.teams/1.about.md
@@ -6,7 +6,7 @@ description: Share a cloud workspace with your team — invite members, assign r
 Basic Memory Teams gives your team a single, shared cloud workspace. Knowledge isn't confined to one person — anything a teammate writes is immediately available to everyone else and to their AI assistants. Edit a note together in real time, hand work off between humans and agents, and build one connected knowledge base instead of scattered copies.
 
 ::note{icon="i-lucide-users"}
-**Teams requires a subscription with one or more seats.** Billing is per seat. Joining or starting a team doesn't change anything about your existing setup — your personal cloud subscription (if you have one) and any local projects keep working exactly as before. Teams adds an organization workspace alongside them.
+**Teams requires a subscription with one or more seats.** Billing is per seat. Joining or starting a team doesn't change anything about your existing setup — your personal cloud subscription (if you have one) and any local projects keep working exactly as before. Teams adds a team workspace alongside them.
 ::
 
 ---
@@ -19,7 +19,7 @@ Your account can have more than one workspace. Each keeps its own projects, note
 |-----------|-------------------|-------|
 | **Local** | Just you, on your machine | No team features; runs entirely on your computer |
 | **Personal Cloud** | Just you | Your personal cloud subscription and notes |
-| **Organization** | Your team | Shared projects, members, roles, and seats |
+| **Team** | Your team | Shared projects, members, roles, and seats |
 
 Switch between workspaces using the workspace selector in the app. Projects and notes are scoped to the workspace you're in.
 
@@ -27,7 +27,7 @@ Switch between workspaces using the workspace selector in the app. Projects and 
 
 ## Roles
 
-Every member of an organization workspace has a role that determines what they can do.
+Every member of a team workspace has a role that determines what they can do.
 
 | Role | Can do |
 |------|--------|
@@ -161,7 +161,7 @@ Team projects come in three visibilities. The right one depends on who needs to 
 
 | Visibility | Who can see it | When to use |
 |------------|----------------|-------------|
-| **Standard** (`workspace`) — _default_ | Everyone in the organization, based on their workspace role (viewer/editor/owner) | Most team work — the open, shared knowledge base |
+| **Standard** (`workspace`) — _default_ | Everyone in the team, based on their workspace role (viewer/editor/owner) | Most team work — the open, shared knowledge base |
 | **Shared** (`shared`) | Only people you grant access to, each at **editor** or **viewer** level | Sensitive topics (hiring, contracts, security audits) where you want a controlled group |
 | **Private** (`private`) | Only the creator | Personal scratch space inside the team workspace |
 
@@ -194,7 +194,7 @@ See [Copy Content Between Workspaces](/teams/copy-between-workspaces) for the pr
 
 Once you're part of a team workspace, team projects show up everywhere you work:
 
-- **In the app** — switch to the organization workspace and your shared projects appear in the sidebar.
+- **In the app** — switch to the team workspace and your shared projects appear in the sidebar.
 - **In your AI assistant (MCP)** — your assistant's project list spans every cloud workspace you can access, so it reaches team projects without extra setup. See [v0.21.0](https://github.com/basicmachines-co/basic-memory/releases/tag/v0.21.0) for details on cross-workspace discovery.
 - **In the CLI** — `bm project list` shows projects across all your workspaces.
 
@@ -214,7 +214,7 @@ You can also target a specific workspace when creating a project, either from th
 
 ## Security and isolation
 
-Each organization gets its **own** isolated database and file storage in the cloud — there is no shared tenancy at the data layer. Your team's knowledge is physically separated from every other team's. Authentication runs through [WorkOS AuthKit](https://workos.com/authkit) for enterprise-grade identity management.
+Each team gets its **own** isolated database and file storage in the cloud — there is no shared tenancy at the data layer. Your team's knowledge is physically separated from every other team's. Authentication runs through [WorkOS AuthKit](https://workos.com/authkit) for enterprise-grade identity management.
 
 ---
 

--- a/content/4.teams/1.about.md
+++ b/content/4.teams/1.about.md
@@ -33,8 +33,8 @@ Every member of a team has a role that determines what they can do.
 |------|--------|
 | **Viewer** | Read-only access to projects and notes |
 | **Editor** | Read and write notes, and create projects |
-| **Billing Admin** | Everything an editor can, plus manage members and invitations |
-| **Admin** | Everything a billing admin can, plus manage API keys, snapshots, and view audit log |
+| **User Admin** | Everything an editor can, plus manage members and invitations |
+| **Admin** | Everything a user admin can, plus manage API keys, snapshots, and view audit log |
 | **Owner** | Everything an admin can, plus manage billing, rename team, and transfer ownership. A team can have only one member with the Owner role. |
 
 

--- a/content/4.teams/1.about.md
+++ b/content/4.teams/1.about.md
@@ -27,18 +27,24 @@ Switch between workspaces using the workspace selector in the app. Projects and 
 
 ## Roles
 
-Every member of a team workspace has a role that determines what they can do.
+Every member of a team has a role that determines what they can do.
 
 | Role | Can do |
 |------|--------|
-| **Owner** | Everything an editor can, plus manage members and invitations, manage billing, and transfer ownership |
-| **Editor** | Read and write notes, and manage invitations |
-| **Viewer** | Read-only access to shared projects |
+| **Viewer** | Read-only access to projects and notes |
+| **Editor** | Read and write notes, and create projects |
+| **Billing Admin** | Everything an editor can, plus manage members and invitations |
+| **Admin** | Everything a billing admin can, plus manage API keys, snapshots, and view audit log |
+| **Owner** | Everything an admin can, plus manage billing, rename team, and transfer ownership. A team can have only one member with the Owner role. |
 
-Members also have a **status**:
+
+
+
+
+Once a invitation has been extended to a user, members also have a **status**:
 
 - **Pending** — invited, but hasn't finished linking their account yet
-- **Active** — full access according to their role
+- **Active** — User has accepted the invitation, thus fully claiming the seat and has full access according to their role
 - **Deactivated** — removed from the team; their history is preserved and their seat is released
 
 ::theme-image{light="/screenshots/cloud-app/v2-settings-teams-light.png" dark="/screenshots/cloud-app/v2-settings-teams-dark.png" alt="Team members list"}

--- a/content/4.teams/1.about.md
+++ b/content/4.teams/1.about.md
@@ -194,7 +194,7 @@ See [Copy Content Between Workspaces](/teams/copy-between-workspaces) for the pr
 
 Once you're part of a team workspace, team projects show up everywhere you work:
 
-- **In the app** — switch to the team workspace and your shared projects appear in the sidebar.
+- **In the app** — Select the project in the sidebar.
 - **In your AI assistant (MCP)** — your assistant's project list spans every cloud workspace you can access, so it reaches team projects without extra setup. See [v0.21.0](https://github.com/basicmachines-co/basic-memory/releases/tag/v0.21.0) for details on cross-workspace discovery.
 - **In the CLI** — `bm project list` shows projects across all your workspaces.
 

--- a/content/4.teams/1.about.md
+++ b/content/4.teams/1.about.md
@@ -164,9 +164,8 @@ Team projects come in three visibilities. The right one depends on who needs to 
 
 | Visibility | Who can see it | When to use |
 |------------|----------------|-------------|
-| **Standard** (`workspace`) — _default_ | Everyone in the team, based on their workspace role (viewer/editor/owner) | Most team work — the open, shared knowledge base |
+| **Standard** (`team`) — _default_ | Everyone in the team, based on their team role (viewer/editor/owner) | Most team work — the open, shared knowledge base |
 | **Shared** (`shared`) | Only people you grant access to, each at **editor** or **viewer** level | Sensitive topics (hiring, contracts, security audits) where you want a controlled group |
-| **Private** (`private`) | Only the creator | Personal scratch space inside the team workspace |
 
 When you create a cloud project, you can set its visibility from the CLI:
 
@@ -195,7 +194,7 @@ See [Copy Content Between Workspaces](/teams/copy-between-workspaces) for the pr
 
 ## Working with team projects
 
-Once you're part of a team workspace, team projects show up everywhere you work:
+Once you're part of a team, projects show up everywhere you work:
 
 - **In the app** — Select the project in the sidebar.
 - **In your AI assistant (MCP)** — your assistant's project list spans every cloud workspace you can access, so it reaches team projects without extra setup. See [v0.21.0](https://github.com/basicmachines-co/basic-memory/releases/tag/v0.21.0) for details on cross-workspace discovery.

--- a/content/4.teams/1.about.md
+++ b/content/4.teams/1.about.md
@@ -38,9 +38,6 @@ Every member of a team has a role that determines what they can do.
 | **Owner** | Everything an admin can, plus manage billing, rename team, and transfer ownership. A team can have only one member with the Owner role. |
 
 
-
-
-
 Once a invitation has been extended to a user, members also have a **status**:
 
 - **Pending** — invited, but hasn't finished linking their account yet

--- a/content/4.teams/2.join-a-team.md
+++ b/content/4.teams/2.join-a-team.md
@@ -25,7 +25,7 @@ On first sign-in, your account is linked to the pending membership, and you beco
 
 ## 2. Switch to the team workspace
 
-Open the app at [app.basicmemory.com](https://app.basicmemory.com). Use the **workspace selector** to switch from your personal workspace to the team's organization workspace.
+Open the app at [app.basicmemory.com](https://app.basicmemory.com). Use the **workspace selector** to switch from your personal workspace to the team workspace.
 
 - Each workspace has its own sidebar, projects, and notes.
 - Switch back to personal anytime — your personal work isn't visible to teammates.

--- a/content/4.teams/2.join-a-team.md
+++ b/content/4.teams/2.join-a-team.md
@@ -24,7 +24,7 @@ On first sign-in, your account is linked to the pending membership, and you beco
 ---
 
 
-## 3. Find the projects
+## 2. Find the projects
 
 The sidebar shows the teams and projects you have access to. Open one to see its folders and notes.
 
@@ -32,15 +32,17 @@ Your **role** determines what you can do:
 
 | Role | You can |
 |------|---------|
-| **Viewer** | Read shared projects |
-| **Editor** | Read and write shared projects; create new notes; manage invitations |
-| **Owner** | Everything an editor can, plus manage members, billing, and project visibility |
+| **Viewer** | Read-only access to projects and notes |
+| **Editor** | Read and write notes, and create projects |
+| **User Admin** | Everything an editor can, plus manage members and invitations |
+| **Admin** | Everything a user admin can, plus manage API keys, snapshots, and view audit log |
+| **Owner** | Everything an admin can, plus manage billing, rename team, and transfer ownership. A team can have only one member with the Owner role. |
 
 Not sure of your role? Open **Settings → Teams** to see it next to your name. If you need a different role, ask an owner or .
 
 ---
 
-## 4. Connect your AI assistant
+## 3. Connect your AI assistant
 
 Your assistant works with the team workspace through the same MCP endpoint as your personal cloud. Pick the path that matches your tool:
 
@@ -69,7 +71,7 @@ From MCP, pass the workspace through `create_memory_project(workspace="acme")` o
 
 ---
 
-## 5. Get oriented
+## 4. Get oriented
 
 A few good first steps in any new team workspace:
 

--- a/content/4.teams/2.join-a-team.md
+++ b/content/4.teams/2.join-a-team.md
@@ -23,18 +23,10 @@ On first sign-in, your account is linked to the pending membership, and you beco
 
 ---
 
-## 2. Switch to the team workspace
 
-Open the app at [app.basicmemory.com](https://app.basicmemory.com). Use the **workspace selector** to switch from your personal workspace to the team workspace.
+## 3. Find the projects
 
-- Each workspace has its own sidebar, projects, and notes.
-- Switch back to personal anytime — your personal work isn't visible to teammates.
-
----
-
-## 3. Find the shared projects
-
-In the team workspace, the sidebar shows the projects you have access to. Open one to see its folders and notes.
+The sidebar shows the teams and projects you have access to. Open one to see its folders and notes.
 
 Your **role** determines what you can do:
 
@@ -44,7 +36,7 @@ Your **role** determines what you can do:
 | **Editor** | Read and write shared projects; create new notes; manage invitations |
 | **Owner** | Everything an editor can, plus manage members, billing, and project visibility |
 
-Not sure of your role? Open **Settings → Teams** to see it next to your name. If you need a different role, ask an owner.
+Not sure of your role? Open **Settings → Teams** to see it next to your name. If you need a different role, ask an owner or .
 
 ---
 

--- a/content/9.reference/1.cli-reference.md
+++ b/content/9.reference/1.cli-reference.md
@@ -384,7 +384,7 @@ bm cloud workspace list
 bm cloud workspace set-default acme
 ```
 
-See [Teams](/teams/about) for working with shared organization workspaces.
+See [Teams](/teams/about) for working with shared team workspaces.
 
 ### Promo controls
 


### PR DESCRIPTION
## Summary
Mirror the web app's user-facing **"Workspace → Team"** relabel (basicmachines-co/basic-memory-cloud#1374). Where the docs called the organization's workspace an **"organization workspace"** (or used the **Organization** workspace type / "the organization"), use **"team workspace" / "Team" / "the team"** instead.

## Scope (intentionally narrow)
Only the organization→team wording changes — 8 lines across 3 files:
- `content/4.teams/1.about.md` — "Teams adds a **team workspace**"; workspace-types table row **Organization → Team** (Local / Personal Cloud / Team); "Every member of a **team workspace**"; "Everyone in the **team**"; "switch to the **team workspace**"; "Each **team** gets its own isolated database".
- `content/4.teams/2.join-a-team.md` — "switch… to the **team workspace**" (matches the section heading).
- `content/9.reference/1.cli-reference.md` — "working with shared **team workspaces**".

## Deliberately unchanged
The `workspace` **container** concept and its taxonomy section, CLI literals (`--workspace`, `bm cloud workspace`, `--visibility workspace`), "workspace selector"/"workspace role" wording, the Copy-Between-Workspaces page/slug, and unrelated uses of "organization" (schema `Organization`, "File Organization", "reorganization"). The team **settings** surface was already documented as "Settings → Teams" with team screenshots, so it already mirrors the renamed UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)