### PR TITLE
Fix Fly deploy health check

### DIFF
--- a/fly.toml.template
+++ b/fly.toml.template
@@ -28,7 +28,7 @@ kill_timeout = '5s'
     timeout = '5s'
     grace_period = '10s'
     method = 'get'
-    path = '/'
+    path = '/healthz'
 
 [[vm]]
   size = 'shared-cpu-1x'

--- a/server/routes/healthz.get.ts
+++ b/server/routes/healthz.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => 'ok')


### PR DESCRIPTION
## Why
The July 4 production deploy failed after the docs overhaul changed `/` into a redirect to `/welcome`. Fly was still health-checking `/`, so the updated machine started successfully but never passed the rollout health gate.

## What Changed
- Add a dedicated `GET /healthz` Nuxt server route that returns `ok`.
- Point the Fly HTTP service check at `/healthz` instead of `/`.

## Implementation Details
Using a stable health endpoint decouples deploy health from docs navigation and root-route redirects. This keeps `/` free to redirect or change content without breaking future Fly rollouts.

## Testing
- `npm run check` passed.
- Generated Fly config shows `path = '/healthz'`.
- Built server local probes:
  - `GET /healthz` -> `200 OK` with `ok`
  - `GET /` -> `301 Moved Permanently` to `/welcome`
  - `GET /welcome` -> `200 OK`

## Risks / Follow-ups
Low risk. The new endpoint is isolated from docs content and only changes Fly deploy health checks.